### PR TITLE
Align stats widget row style

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,11 +65,12 @@
     </section>
     
   <!-- 🚀 统计卡片 START -->
-<iframe src="./stats-widget.html"
-        loading="lazy"
-        class="stats-widget-iframe">
-</iframe>
-<!-- 🚀 统计卡片 END -->
+  <section class="stats-wrapper wrapper">
+    <iframe src="./stats-widget.html"
+            loading="lazy"
+            class="stats-widget-iframe"></iframe>
+  </section>
+  <!-- 🚀 统计卡片 END -->
     
     <!-- Chatbox BEGIN -->
     <section class="chatbox wrapper">

--- a/style.css
+++ b/style.css
@@ -192,14 +192,14 @@ header {
 
 /* Business Tags */
 .business-tags {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 28px;
-  margin: 20px 0 10px 0; /* Consolidated margin */
-  flex-wrap: wrap;
-  width: 100%; /* Was fit-content in one version */
-  max-width: 100%; /* From original style.css */
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin: 20px auto 10px auto;
+  width: calc(100% - 40px);
+  max-width: 760px;
+  padding: 0 20px;
+  justify-items: center;
 }
 .business-tag { /* From original style.css, seems more detailed */
   font-size: 1.5rem;
@@ -211,7 +211,7 @@ header {
   letter-spacing: 2.5px;
   border: none;
   text-align: center;
-  margin: 0 6px; /* One version had 0 4px */
+  margin: 0; /* Align with grid gap */
   cursor: pointer;
   position: relative;
   transition: 
@@ -243,10 +243,12 @@ header {
 }
 @media (max-width: 600px) {
   .business-tags {
+    display: flex;
     flex-direction: column;
     gap: 12px;
     margin: 18px auto 8px auto;
     width: 100%;
+    padding: 0;
   }
   .business-tag {
     font-size: 1.05rem;
@@ -398,6 +400,12 @@ iframe[src*="chat.svtrglobal.com"] {
   border: none;
   overflow: hidden;
   border-radius: 12px;
+}
+
+.stats-wrapper {
+  background: var(--bg-panel);
+  border-left: 1px solid rgba(0,0,0,0.1);
+  border-right: 1px solid rgba(0,0,0,0.1);
 }
 
 .chat-iframe {


### PR DESCRIPTION
## Summary
- adjust business tags layout to grid for better alignment with stats widget
- remove tag side margins and tweak mobile rule

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686f5f454b80832f9e453e242c205658