### PR TITLE
Improve stats widget mobile layout

### DIFF
--- a/stats-widget.html
+++ b/stats-widget.html
@@ -116,8 +116,24 @@ body{background:transparent;display:flex;align-items:center;justify-content:cent
 @keyframes flash{0%{transform:scale(1)}50%{transform:scale(1.08)}100%{transform:scale(1)}}
 
 /* 🎯 移动端优化 */
-/* 移除响应式列数变更，保持三列一行 */
-    /* 确保body高度自适应内容 */
+@media (max-width: 600px) {
+  .stats-container {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+  .stat-card {
+    padding: 20px 16px;
+  }
+  html,body {
+    height: auto;
+    overflow-y: auto;
+  }
+  body {
+    display: block;
+    align-items: flex-start;
+  }
+}
+/* 确保body高度自适应内容 */
 body {
   height: 100%;
   min-height: 100%;


### PR DESCRIPTION
## Summary
- adjust CSS in `stats-widget.html` so that stat cards stack on narrow screens
- allow vertical scrolling on small devices

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687017d6cb64832fae5af0110b9d9612