### PR TITLE
Add English support for stats widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
         notice_3: 'If you are a Member, please visit SVTR.AI',
         link_members: 'Exclusive Members Area',
         chat_header: 'Chat with <a href="https://svtr.ai" target="_blank">SVTR.AI</a>',
-        tag_database_text: 'AI DB',
+        tag_database_text: 'AI Database',
         tag_meetup_text: 'AI Meetup',
         tag_camp_text: 'AI Camp',
         menu_toggle_aria_label: 'Open/Close menu',

--- a/index.html
+++ b/index.html
@@ -163,6 +163,8 @@
       }
     };
 
+    const statsIframe = document.querySelector('.stats-widget-iframe');
+
     function updateLanguage(lang) {
       document.documentElement.lang = lang;
       const keysForInnerHTML = ['chat_header']; // Add other keys here if they also contain HTML
@@ -199,6 +201,10 @@
       document.getElementById('btnEn').classList.toggle('active', lang === 'en');
       // 同步title
       document.title = translations[lang].title;
+
+      if (statsIframe && statsIframe.contentWindow) {
+        statsIframe.contentWindow.postMessage({ type: 'setLang', lang }, '*');
+      }
     }
 
     document.getElementById('btnZh').addEventListener('click', () => updateLanguage('zh-CN'));

--- a/stats-widget.html
+++ b/stats-widget.html
@@ -145,28 +145,28 @@ body {
 <body>
 <div class="stats-container">
   <a class="stat-card members" href="https://c0uiiy15npu.feishu.cn/share/base/form/shrcnKdKrgumC9OtjQNXiC05r8e" target="_blank">
-    <div class="live-indicator"><div class="live-dot"></div><span>实时</span></div>
+    <div class="live-indicator"><div class="live-dot"></div><span data-i18n="live">实时</span></div>
     <div class="stat-icon" aria-label="社区成员">👥</div>
     <div class="stat-number" id="members-count">121,884</div>
-    <div class="stat-label">社区成员</div>
+    <div class="stat-label" data-i18n="members">社区成员</div>
     <div class="progress-bar"><div class="progress-fill" style="width:85%"></div></div>
     <div class="growth-indicator">↗ <span id="members-growth">+25/小时</span></div>
   </a>
 
   <a class="stat-card companies" href="https://c0uiiy15npu.feishu.cn/share/base/form/shrcnxRAVSwtEHD40UUUg1086Gf" target="_blank">
-    <div class="live-indicator"><div class="live-dot"></div><span>实时</span></div>
+    <div class="live-indicator"><div class="live-dot"></div><span data-i18n="live">实时</span></div>
     <div class="stat-icon" aria-label="创业公司与投资机构">🏢</div>
     <div class="stat-number" id="companies-count">10,761</div>
-    <div class="stat-label">创业公司与投资机构</div>
+    <div class="stat-label" data-i18n="companies">创业公司与投资机构</div>
     <div class="progress-bar"><div class="progress-fill" style="width:68%"></div></div>
     <div class="growth-indicator">↗ <span id="companies-growth">+8/小时</span></div>
   </a>
 
   <a class="stat-card vip" href="https://c0uiiy15npu.feishu.cn/wiki/G0oMwUeNbiZkQBkX9iXcfMllnpe?from=from_copylink" target="_blank">
-    <div class="live-indicator"><div class="live-dot"></div><span>实时</span></div>
+    <div class="live-indicator"><div class="live-dot"></div><span data-i18n="live">实时</span></div>
     <div class="stat-icon" aria-label="权益会员">💎</div>
     <div class="stat-number" id="vip-count">1,102</div>
-    <div class="stat-label">权益会员</div>
+    <div class="stat-label" data-i18n="vip">权益会员</div>
     <div class="progress-bar"><div class="progress-fill" style="width:42%"></div></div>
     <div class="growth-indicator">↗ <span id="vip-growth">+3/小时</span></div>
   </a>
@@ -179,28 +179,66 @@ const stats={
   companies:{c:10761,g:8,m:20000},
   vip:{c:1102,g:3,m:2000}
 };
+
+const translations={
+  'zh-CN':{
+    live:'实时',members:'社区成员',companies:'创业公司与投资机构',vip:'权益会员',perHour:'/小时'
+  },
+  'en':{
+    live:'Live',members:'Members',companies:'Startups & Investors',vip:'VIP Members',perHour:'/hr'
+  }
+};
+let currentLang='zh-CN';
+
 function $(id){return document.getElementById(id)}
+
+function updateLang(lang){
+  if(!translations[lang]) lang='zh-CN';
+  currentLang=lang;
+  document.documentElement.lang=lang;
+  const t=translations[lang];
+  document.querySelectorAll('.live-indicator span').forEach(el=>el.textContent=t.live);
+  document.querySelector('.members .stat-label').textContent=t.members;
+  document.querySelector('.members .stat-icon').setAttribute('aria-label',t.members);
+  document.querySelector('.companies .stat-label').textContent=t.companies;
+  document.querySelector('.companies .stat-icon').setAttribute('aria-label',t.companies);
+  document.querySelector('.vip .stat-label').textContent=t.vip;
+  document.querySelector('.vip .stat-icon').setAttribute('aria-label',t.vip);
+  paint();
+}
+
 function paint(){
-  members_count.textContent = stats.members.c.toLocaleString()
-  companies_count.textContent = stats.companies.c.toLocaleString()
-  vip_count.textContent = stats.vip.c.toLocaleString()
-  members_growth.textContent = `+${stats.members.g}/小时`
-  companies_growth.textContent = `+${stats.companies.g}/小时`
-  vip_growth.textContent = `+${stats.vip.g}/小时`
-  updateBars()
+  members_count.textContent=stats.members.c.toLocaleString();
+  companies_count.textContent=stats.companies.c.toLocaleString();
+  vip_count.textContent=stats.vip.c.toLocaleString();
+  const per=translations[currentLang].perHour;
+  members_growth.textContent=`+${stats.members.g}${per}`;
+  companies_growth.textContent=`+${stats.companies.g}${per}`;
+  vip_growth.textContent=`+${stats.vip.g}${per}`;
+  updateBars();
 }
+
 function flash(el){el.classList.add('increase-animation');setTimeout(()=>el.classList.remove('increase-animation'),500)}
+
 function updateBars(){
-  document.querySelector('.members .progress-fill').style.width = Math.min(stats.members.c/stats.members.m*100,100)+'%'
-  document.querySelector('.companies .progress-fill').style.width = Math.min(stats.companies.c/stats.companies.m*100,100)+'%'
-  document.querySelector('.vip .progress-fill').style.width = Math.min(stats.vip.c/stats.vip.m*100,100)+'%'
+  document.querySelector('.members .progress-fill').style.width=Math.min(stats.members.c/stats.members.m*100,100)+'%';
+  document.querySelector('.companies .progress-fill').style.width=Math.min(stats.companies.c/stats.companies.m*100,100)+'%';
+  document.querySelector('.vip .progress-fill').style.width=Math.min(stats.vip.c/stats.vip.m*100,100)+'%';
 }
+
 function loop(){
   Object.entries(stats).forEach(([k,v])=>{
     if(Math.random()<.5){v.c+=Math.ceil(v.g*(0.7+Math.random()*0.6));flash($(k+'-count'))}
-  });paint()
+  });paint();
 }
-paint();setInterval(loop,60000);
+
+window.addEventListener('message',e=>{
+  if(e.data&&e.data.type==='setLang')updateLang(e.data.lang);
+});
+
+const params=new URLSearchParams(location.search);
+updateLang(params.get('lang')||'zh-CN');
+setInterval(loop,60000);
 </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -209,6 +209,7 @@ header {
   background: linear-gradient(90deg, #fff176 10%, #ffa726 90%);
   color: #333;
   letter-spacing: 2.5px;
+  white-space: nowrap;
   border: none;
   text-align: center;
   margin: 0; /* Align with grid gap */
@@ -255,6 +256,7 @@ header {
     padding: 12px 0;
     min-width: 70vw;
     margin: 0 auto;
+    white-space: nowrap;
   }
 }
 <!-- 🚀 统计卡片 START -->


### PR DESCRIPTION
## Summary
- add translation mapping for stats widget and handle language messages
- sync widget language from the main page

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_68727abf4a1c832fb7b94a0e7fb439fb