### PR TITLE
Fix English tag labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
         notice_3: 'If you are a Member, please visit SVTR.AI',
         link_members: 'Exclusive Members Area',
         chat_header: 'Chat with <a href="https://svtr.ai" target="_blank">SVTR.AI</a>',
-        tag_database_text: 'AI Database',
+        tag_database_text: 'AI DB',
         tag_meetup_text: 'AI Meetup',
         tag_camp_text: 'AI Camp',
         menu_toggle_aria_label: 'Open/Close menu',

--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
         notice_3: 'If you are a Member, please visit SVTR.AI',
         link_members: 'Exclusive Members Area',
         chat_header: 'Chat with <a href="https://svtr.ai" target="_blank">SVTR.AI</a>',
-        tag_database_text: 'AI DB',
+        tag_database_text: 'AI Database',
         tag_meetup_text: 'AI Meetup',
         tag_camp_text: 'AI Camp',
         menu_toggle_aria_label: 'Open/Close menu',

--- a/style.css
+++ b/style.css
@@ -210,6 +210,7 @@ header {
   color: #333;
   letter-spacing: 2.5px;
   white-space: nowrap;
+  width: 100%;
   border: none;
   text-align: center;
   margin: 0; /* Align with grid gap */
@@ -254,8 +255,8 @@ header {
   .business-tag {
     font-size: 1.05rem;
     padding: 12px 0;
-    min-width: 70vw;
-    margin: 0 auto;
+    width: 100%;
+    margin: 0;
   }
 }
 <!-- 🚀 统计卡片 START -->

--- a/style.css
+++ b/style.css
@@ -209,6 +209,7 @@ header {
   background: linear-gradient(90deg, #fff176 10%, #ffa726 90%);
   color: #333;
   letter-spacing: 2.5px;
+  white-space: nowrap;
   border: none;
   text-align: center;
   margin: 0; /* Align with grid gap */


### PR DESCRIPTION
## Summary
- tweak English tag labels
- keep tag buttons on a single line

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6872831615c4832f811828f3f9734559